### PR TITLE
fix: Fix sass rgb compatibility

### DIFF
--- a/src/Vue3DatePicker/style/components/_DatepickerMenu.scss
+++ b/src/Vue3DatePicker/style/components/_DatepickerMenu.scss
@@ -36,7 +36,7 @@
 .dp__menu_disabled {
   @extend %__dp_menu_readonly_disabled;
 
-  background: rgb(255 255 255 / 50%);
+  background: rgba(255, 255, 255, 0.5);
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
Since version 2.4.3 importing this file:

```
vue3-date-time-picker/src/Vue3DatePicker/style/main.scss
```

may result in compilation issues:

```
SassError: Function rgb is missing argument $green.
        on line 3 of node_modules/vue3-date-time-picker/src/Vue3DatePicker/style/main.scss
        from line 2 of src/App.vue
>>   background: rgb(255 255 255 / 50%);
   --------------^
```

This can be fixed by using the syntax:

```
rgba(255, 255, 255, 0.5)
```

Note that I couldn't use `npm run lint` because it automatically reverts this fix. I'm not sure what's your preferred way to get around that.

This issue was introduced with these changes: https://github.com/Vuepic/vue3-date-time-picker/issues/70